### PR TITLE
Load the example directories properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
+<title>Directory listing for /examples/</title>
+<body>
+<h2>Directory listing for /examples/</h2>
+<hr>
+<ul>
+<li><a href="examples/boxes/">boxes/</a>
+<li><a href="examples/linegraph-3d/">linegraph-3d/</a>
+<li><a href="examples/sunburst/">sunburst/</a>
+<li><a href="examples/treemap/">treemap/</a>
+</ul>
+<hr>
+</body>
+</html>
+

--- a/runTestWebServer.sh
+++ b/runTestWebServer.sh
@@ -5,5 +5,5 @@
 # Due to security restrictions in the browser, these requests are not allowed to target local files,
 # even if the requesting page is also local.
 
-cd ../examples
+#cd examples
 python -m SimpleHTTPServer 8888


### PR DESCRIPTION
The examples didn't run in a context that allowed them to see the superconductorjs directory. Move the webserver to run up a directory and added this simple index.html.
